### PR TITLE
Fix for build on Linux without errors

### DIFF
--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -28,6 +28,8 @@
 #include <unistd.h>
 #include "ErrorMessage.h"
 
+#include <pthread.h>
+
 namespace System {
 
 namespace {

--- a/src/Serialization/KVBinaryOutputStreamSerializer.cpp
+++ b/src/Serialization/KVBinaryOutputStreamSerializer.cpp
@@ -22,6 +22,8 @@
 #include <stdexcept>
 #include <Common/StreamTools.h>
 
+#include <limits>
+
 using namespace Common;
 using namespace CryptoNote;
 


### PR DESCRIPTION
Hello! I had 10 errors when built in Linux, I've fixed here:
```

##2024-12-12 12:50 Evilbit EVI install
#https://github.com/evilmortyyy/evilbit
git clone --recursive https://github.com/evilmortyyy/evilbit.git
cd evilbit; mkdir build; cd build
cmake ..
cd ..
make
  [ 16%] Building CXX object src/CMakeFiles/Common.dir/Common/Math.cpp.o
  In file included from /mnt/blockchains/crypto/testing/evi/evilbit/src/Common/Math.cpp:18:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Common/Math.h: In function ‘void Common::integer_cast_throw(const Source&)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Common/Math.h:47:27: error: ‘numeric_limits’ is not a member of ‘std’
     47 |     Common::toString(std::numeric_limits<Target>::min()) + ".." +
        |                           ^~~~~~~~~~~~~~
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Common/Math.h:47:51: error: ‘::min’ has not been declared; did you mean ‘std::min’?
     47 |     Common::toString(std::numeric_limits<Target>::min()) + ".." +
        |                                                   ^~~
        |                                                   std::min
v src/Common/Math.h
  24: #include <limits>
mk
  [ 32%] Building CXX object src/CMakeFiles/Crypto.dir/crypto/slow-hash.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/crypto/slow-hash.cpp: In destructor ‘Crypto::cn_context::~cn_context()’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/crypto/slow-hash.cpp:69:12: error: ‘terminate’ is not a member of ‘std’
     69 |       std::terminate();
        |            ^~~~~~~~~
  make[3]: *** [src/CMakeFiles/Crypto.dir/build.make:328: src/CMakeFiles/Crypto.dir/crypto/slow-hash.cpp.o] Error 1
  make[3]: Leaving directory '/mnt/blockchains/crypto/testing/evi/evilbit/build/release'

v src/crypto/slow-hash.cpp
  29: #include <exception>
mk
  [ 62%] Building CXX object src/CMakeFiles/Serialization.dir/Serialization/KVBinaryOutputStreamSerializer.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Serialization/KVBinaryOutputStreamSerializer.cpp: In function ‘void {anonymous}::writeElementName(Common::IOutputStream&, Common::StringView)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Serialization/KVBinaryOutputStreamSerializer.cpp:44:29: error: ‘numeric_limits’ is not a member of ‘std’
     44 |   if (name.getSize() > std::numeric_limits<uint8_t>::max()) {
        |                             ^~~~~~~~~~~~~~
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Serialization/KVBinaryOutputStreamSerializer.cpp:44:51: error: expected primary-expression before ‘>’ token
     44 |   if (name.getSize() > std::numeric_limits<uint8_t>::max()) {
        |                                                   ^
v src/Serialization/KVBinaryOutputStreamSerializer.cpp
  25: #include <limits>
mk
  [ 65%] Building CXX object src/CMakeFiles/System.dir/Platform/Linux/System/Dispatcher.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Platform/Linux/System/Dispatcher.cpp: In constructor ‘System::{anonymous}::MutextGuard::MutextGuard(pthread_mutex_t&)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Platform/Linux/System/Dispatcher.cpp:43:16: error: ‘pthread_mutex_lock’ was not declared in this scope; did you mean ‘pthread_mutex_t’?
     43 |     auto ret = pthread_mutex_lock(&mutex);
        |                ^~~~~~~~~~~~~~~~~~
        |                pthread_mutex_t
v src/Platform/Linux/System/Dispatcher.cpp
  31:#include <stdexcept>
  #include <pthread.h>
mk
  [ 73%] Building CXX object src/CMakeFiles/Transfers.dir/Transfers/BlockchainSynchronizer.cpp.o
  In file included from /mnt/blockchains/crypto/testing/evi/evilbit/src/Transfers/BlockchainSynchronizer.cpp:29:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/CryptoNoteCore/CryptoNoteBasicImpl.h:31:29: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     31 |   struct array_hasher: std::unary_function<t_array&, size_t>
        |                             ^~~~~~~~~~~~~~
  In file included from /usr/include/c++/12/functional:49,
                   from /mnt/blockchains/crypto/testing/evi/evilbit/include/INode.h:22,
                   from /mnt/blockchains/crypto/testing/evi/evilbit/src/Transfers/BlockchainSynchronizer.h:20,
                   from /mnt/blockchains/crypto/testing/evi/evilbit/src/Transfers/BlockchainSynchronizer.cpp:20:
  /usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Transfers/BlockchainSynchronizer.cpp: In member function ‘void CryptoNote::BlockchainSynchronizer::processBlocks(GetBlocksResponse&)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/Transfers/BlockchainSynchronizer.cpp:538:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
    538 |         std::this_thread::sleep_for(std::chrono::milliseconds(100));
        |                           ^~~~~~~~~
v src/Transfers/BlockchainSynchronizer.cpp
  33:#include <thread>
mk
  [ 91%] Building CXX object src/CMakeFiles/GreenWallet.dir/GreenWallet/Fusion.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Fusion.cpp: In function ‘bool optimize(CryptoNote::WalletGreen&, uint64_t)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Fusion.cpp:151:23: error: ‘sleep_for’ is not a member of ‘std::this_thread’
    151 |     std::this_thread::sleep_for(std::chrono::seconds(1));
        |                       ^~~~~~~~~
v src/GreenWallet/Fusion.cpp
  20:#include <thread>
mk
  [ 89%] Building CXX object src/CMakeFiles/GreenWallet.dir/GreenWallet/GetInput.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/GetInput.cpp: In function ‘std::string getInputAndWorkInBackground(const std::vector<_Tp>&, std::string, bool, std::shared_ptr<WalletInfo>)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/GetInput.cpp:94:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
     94 |             std::this_thread::sleep_for(std::chrono::milliseconds(50));
        |                               ^~~~~~~~~
v src/GreenWallet/GetInput.cpp
  16: #include <thread>
mk
  [ 90%] Building CXX object src/CMakeFiles/GreenWallet.dir/GreenWallet/Sync.cpp.o
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Sync.cpp: In function ‘void syncWallet(CryptoNote::INode&, std::shared_ptr<WalletInfo>)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Sync.cpp:211:27: error: ‘sleep_for’ is not a member of ‘std::this_thread’
    211 |         std::this_thread::sleep_for(std::chrono::seconds(waitSeconds));
        |                           ^~~~~~~~~
v src/GreenWallet/Sync.cpp
  21:#include <thread>
mk
  [ 89%] Building CXX object src/CMakeFiles/GreenWallet.dir/GreenWallet/Tools.cpp.o
  In file included from /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Tools.cpp:17:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/CryptoNoteCore/CryptoNoteBasicImpl.h:31:29: warning: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Wdeprecated-declarations]
     31 |   struct array_hasher: std::unary_function<t_array&, size_t>
        |                             ^~~~~~~~~~~~~~
  In file included from /usr/include/c++/12/bits/unique_ptr.h:37,
                   from /usr/include/c++/12/memory:76,
                   from /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Tools.h:9,
                   from /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Tools.cpp:7:
  /usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
    117 |     struct unary_function
        |            ^~~~~~~~~~~~~~
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Tools.cpp: In lambda function:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Tools.cpp:312:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
    312 |             std::this_thread::sleep_for(std::chrono::seconds(1));
        |                               ^~~~~~~~~
v src/GreenWallet/Tools.cpp
  27: #include <thread>
mk
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Transfer.cpp: In function ‘void sendMultipleTransactions(CryptoNote::WalletGreen&, std::vector<CryptoNote::TransactionParameters>)’:
  /mnt/blockchains/crypto/testing/evi/evilbit/src/GreenWallet/Transfer.cpp:198:31: error: ‘sleep_for’ is not a member of ‘std::this_thread’
    198 |             std::this_thread::sleep_for(std::chrono::seconds(5));
        |                               ^~~~~~~~~
v src/GreenWallet/Transfer.cpp
  23: #include <thread>
mk
  [100%] Linking CXX executable miner
  make[3]: Leaving directory '/mnt/blockchains/crypto/testing/evi/evilbit/build/release'
  [100%] Built target Miner
  make[2]: Leaving directory '/mnt/blockchains/crypto/testing/evi/evilbit/build/release'
  make[1]: Leaving directory '/mnt/blockchains/crypto/testing/evi/evilbit/build/release'
  Thu Dec 12 01:23:01 PM MSK 2024
  start date was Thu Dec 12 01:22:33 PM MSK 2024
ls build/release/src
  CMakeFiles               libCrypto.a              libLogging.a       libSerialization.a  optimizer
  evilbitd                 libCryptoNoteCore.a      libMnemonics.a     libSystem.a         simplewallet
  greenwallet              libCryptoNoteProtocol.a  libNodeRpcProxy.a  libTransfers.a      walletd
  libBlockchainExplorer.a  libHttp.a                libP2P.a           libWallet.a
  libCheckpoints.a         libInProcessNode.a       libPaymentGate.a   Makefile
  libCommon.a              libJsonRpcServer.a       libRpc.a           miner
  ##so, built with 10 corrections
```

Then I forked and saw that some lines actually presented there and need to add just these:
```
vim src/Serialization/KVBinaryOutputStreamSerializer.cpp
  25: #include <limits>
vim src/Platform/Linux/System/Dispatcher.cpp
  31:#include <pthread.h>
```

With these two corrections I built fine. Could you accept lupp-request?
